### PR TITLE
Fix logging issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,17 @@
+0.1.4 (Not released yet)
+========================
+
+- Added messages when no file matches the `--obstype` value, by default is
+  `FOCUS` [#9]
+- Replaced `parser.error` by `log.error` and `sys.exit` when the directory does
+  not exist and when exists but is empty.
+- Added test for cases when the directory does not exist, when is empty and when
+  no file matches the selection on `--obstype` which by default is `FOCUS`.
+- Replaced `logging.config.dictConfig` by `logging.basicConfig` which fixed
+  several issues. For instance `--debug` was unusable, and also there were
+  duplicated log entries for the file handler when used as a library in other
+  application. [#10]
+
 0.1.3
 =====
 

--- a/goodman_focus/goodman_focus.py
+++ b/goodman_focus/goodman_focus.py
@@ -15,47 +15,18 @@ from scipy import signal
 import logging
 import logging.config
 
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': True,
-    'formatters': {
-        'standard': {
-            'format': '[%(asctime)s][%(levelname)s]: %(message)s',
-            'datefmt': '%H:%M:%S',
-        }
-    },
-    'handlers': {
-        'console': {
-            'level': 'DEBUG',
-            'formatter': 'standard',
-            'class': 'logging.StreamHandler',
-        },
-        'rotate_file': {
-            'level': 'DEBUG',
-            'formatter': 'standard',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'filename': 'focus_finder.log',
-            'encoding': 'utf8',
-            'maxBytes': 100000,
-            'backupCount': 1,
-        }
-    },
-    'loggers': {
-        '': {
-            'handlers': ['console', 'rotate_file'],
-            'level': 'DEBUG',
-        },
-}
-}
 
 LOG_FORMAT = '[%(asctime)s][%(levelname)s]: %(message)s'
 LOG_LEVEL = logging.INFO
 
 DATE_FORMAT = '%H:%M:%S'
 
-formatter = logging.Formatter(fmt=LOG_FORMAT, datefmt=DATE_FORMAT)
+# for file handler
+# formatter = logging.Formatter(fmt=LOG_FORMAT, datefmt=DATE_FORMAT)
 
-logging.config.dictConfig(LOGGING)
+logging.basicConfig(level=LOG_LEVEL,
+                    format=LOG_FORMAT,
+                    datefmt=DATE_FORMAT)
 
 log = logging.getLogger(__name__)
 

--- a/goodman_focus/version.py
+++ b/goodman_focus/version.py
@@ -1,2 +1,2 @@
 # This is an automatic generated file please do not edit
-__version__ = '0.1.3'
+__version__ = '0.1.4.dev1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,4 +32,4 @@ install_requires =
     sphinx>=2.1.2
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.1.3
+version = 0.1.4.dev1


### PR DESCRIPTION
using `logging.config.dictConfig` created several side effects
- Unable to use ``--debug`` keyword
- Creates duplicated log files.

This PR fixes that

Closes #10 